### PR TITLE
Release 1.0.5

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,12 @@ variable "alb_listener_priority" {
 
 variable "subdomain" {
   type        = string
-  description = "subdomain for the DNS record and listener, typically \"$${var.app_name}-pma\""
+  description = "subdomain for the DNS record and listener, typically app_name + \"pma\""
 }
 
 variable "cloudflare_domain" {
   type        = string
-  description = "domain name registered with Cloudflare. phpMyAdmin hostname will be \"$${var.subdomain}.$${var.cloudflare_domain}\""
+  description = "domain name registered with Cloudflare"
 }
 
 variable "rds_address" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,12 @@ variable "alb_listener_priority" {
 
 variable "subdomain" {
   type        = string
-  description = "subdomain for the DNS record and listener, typically \"${var.app_name}-pma\""
+  description = "subdomain for the DNS record and listener, typically \"$${var.app_name}-pma\""
 }
 
 variable "cloudflare_domain" {
   type        = string
-  description = "domain name registered with Cloudflare. phpMyAdmin hostname will be \"${var.subdomain}.${var.cloudflare_domain}\""
+  description = "domain name registered with Cloudflare. phpMyAdmin hostname will be \"$${var.subdomain}.$${var.cloudflare_domain}\""
 }
 
 variable "rds_address" {


### PR DESCRIPTION
escape the `$` as `$$` to bypass interpolation, which is not allowed in a variable description