### PR TITLE
Release 1.1.3

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "alb_https_listener_arn" {
 }
 
 variable "alb_listener_priority" {
-  default     = "30"
+  default     = null
   description = "load balancer listener priority"
 }
 


### PR DESCRIPTION
### Fixed
- Set `alb_listener_priority` default to `null` to avoid conflict between instances.