### PR TITLE
Release 2.0.0 - replace the lifecycle rule when the target group changes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,9 +27,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    # Install the latest version of Terraform CLI
+    # Install the earliest version of Terraform CLI supported by this module
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
+      with: 
+        terraform_version: '~> 1.1'
 
     # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with: 
-        terraform_version: '~> 1.1'
+        terraform_version: '~> 1.2'
 
     # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.1"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ resource "aws_alb_listener_rule" "phpmyadmin" {
       values = ["${var.subdomain}.${var.cloudflare_domain}"]
     }
   }
+
+  lifecycle {
+    replace_triggered_by = [aws_alb_target_group.phpmyadmin]
+  }
 }
 
 module "ecsservice" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.1"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
### Added
- Added a `replace_triggered_by` lifecycle rule to the ALB listener rule to facilitate changes to the target group. This should make it possible to make changes that require the target group to be replaced. Without this, the listener rule prevents Terraform from deleting the target group. BREAKING CHANGE: Requires Terraform version 1.2 or greater. 