### PR TITLE
Update AWS provider configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ example configuration:
 ```hcl
 provider "aws" {
   region     = var.aws_region
-  access_key = var.aws_access_key_id
-  secret_key = var.aws_secret_access_key
 }
 ```
 


### PR DESCRIPTION
Removed access key and secret key from example AWS provider configuration. Using a static key is not the best recommendation.