### PR TITLE
add a "try" to fix failure during destroy while active

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
 output "phpmyadmin_url" {
-  value = var.enable ? cloudflare_record.pmadns[0].hostname : ""
+  value = var.enable ? try(cloudflare_record.pmadns[0].hostname, "") : ""
 }
-


### PR DESCRIPTION
[ITSE-1251](https://support.gtis.sil.org/issue/ITSE-1251) terraform-aws-phpmyadmin #4: destroy with enable=true fails

### Fixed
- an invalid reference that occurs if the module is destroyed while `enable` is true.